### PR TITLE
Fix modifier grab when used with dash-to-panel extension

### DIFF
--- a/src/extension/app.ts
+++ b/src/extension/app.ts
@@ -314,10 +314,13 @@ class App {
         });
 
         global.display.connect('grab-op-begin', (_display: Display, win: Window) => {
+            // only start isGrabbing if is a valid window to avoid conflict 
+            // with dash-to-panel/appIcons.js:1021 where are emitting a grab-op-begin
+            // without never emitting a grab-op-end
+            if (!validWindow(win)) return;
+            
             const useModifier = getBoolSetting(SETTINGS.USE_MODIFIER);
             this.isGrabbing = true;
-
-            if (!validWindow(win)) return;
 
             if (useModifier &&
                 !this.modifiersManager.isHolding(MODIFIERS_ENUM.CONTROL))


### PR DESCRIPTION
Only start isGrabbing if is a valid window to avoid conflict with dash-to-panel that are emitting a grab-op-begin without never emitting a grab-op-end.

[dash-to-panel/appIcons.js:1021](https://github.com/home-sweet-gnome/dash-to-panel/blob/71753d8ccda32db0068b56f90361e73cfa0df1d3/appIcons.js#L1021)