### PR TITLE
Add support for gnome 43

### DIFF
--- a/src/metadata.json
+++ b/src/metadata.json
@@ -6,7 +6,8 @@
   "shell-version": [
       "40",
       "41",
-      "42"
+      "42",
+      "43"
   ],
   "url": "https://github.com/micahosborne/gSnap",
   "settings-schema": "org.gnome.shell.extensions.gsnap",


### PR DESCRIPTION
I've been running this for a day or 2 like on Fedora 37 that has Gnome 43