### PR TITLE
feat: Add menu item for settings

### DIFF
--- a/src/extension/app.ts
+++ b/src/extension/app.ts
@@ -487,6 +487,12 @@ class App {
             launcher.menu.addMenuItem(editLayoutButton);
             launcher.menu.addMenuItem(renameLayoutButton);
             launcher.menu.addMenuItem(newLayoutButton);
+
+            // Add an entry-point for more settings
+            launcher.menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
+            const settingsButton = launcher.menu.addAction('Settings',
+                () => ExtensionUtils.openPrefs());
+            launcher.menu.addMenuItem(settingsButton);
         }
 
 


### PR DESCRIPTION
Closes #62

This adds a new _Settings_ item in the menu that goes to the extension settings dialog. This allows accessing extension settings without having to have Gnome Extension Manager installed.

Here's what it looks like:

![gsnap-settings-menu-item](https://github.com/GnomeSnapExtensions/gSnap/assets/346123/fd0d754c-f03d-40fe-94f3-856472099cc1)
