### PR TITLE
Add support for GNOME 46

### DIFF
--- a/src/metadata.json
+++ b/src/metadata.json
@@ -3,7 +3,7 @@
   "name": "gSnap",
   "description": "Organize windows in customizable snap zones like FancyZones on Windows.",
   "version": 17,
-  "shell-version": ["45"],
+  "shell-version": ["45", "46"],
   "url": "https://github.com/GnomeSnapExtensions/gSnap",
   "settings-schema": "org.gnome.shell.extensions.gsnap",
   "gettext-domain": "gsnap@micahosborne"


### PR DESCRIPTION
I haven't noticed any issues with GNOME 46 (Fedora 40 Beta).

Resolves #82 