### PR TITLE
Change the fullscreen handling so that each monitor gets checked individually

### DIFF
--- a/src/extension/app.ts
+++ b/src/extension/app.ts
@@ -331,15 +331,14 @@ export default class App extends Extension {
         });
 
         global.display.connect('in-fullscreen-changed', (_display: Display) => {
-            if (global.display.get_monitor_in_fullscreen(0)) {
-                activeMonitors().forEach(m => {
+            activeMonitors().forEach(m => {
+                if (global.display.get_monitor_in_fullscreen(m.index)) {
                     this.tabManager[m.index]?.destroy();
                     this.tabManager[m.index] = null;
-                });
-            } else {
-                this.setToCurrentWorkspace();
-            }
-
+                } else {
+                    this.setToCurrentWorkspace(m.index);
+                }
+            });
         });
     
 
@@ -869,11 +868,16 @@ export default class App extends Extension {
      */
     onFocus() { }
 
-    private setToCurrentWorkspace() {
+    private setToCurrentWorkspace(monitorIndex?: number) {
         let currentWorkspaceIdx = WorkspaceManager.get_active_workspace().index();
-        activeMonitors().forEach(m => {
-            let currentLayoutIdx = this.getWorkspaceMonitorCurrentLayoutOrDefault(currentWorkspaceIdx, m.index);
-            this.setLayout(currentLayoutIdx, m.index);
-        });
+        if (monitorIndex !== undefined) {
+            let currentLayoutIdx = this.getWorkspaceMonitorCurrentLayoutOrDefault(currentWorkspaceIdx, monitorIndex);
+            this.setLayout(currentLayoutIdx, monitorIndex);
+        } else {
+            activeMonitors().forEach(m => {
+                let currentLayoutIdx = this.getWorkspaceMonitorCurrentLayoutOrDefault(currentWorkspaceIdx, m.index);
+                this.setLayout(currentLayoutIdx, m.index);
+            });
+        }
     }
 }


### PR DESCRIPTION
This pull request contains a small change to the fullscreen changed method.

**Before**, when an app changes from / to fullscreen, only the fullscreen status of monitor `0` was checked. 
**Now** every monitor gets checked individually. When a monitor is in fullscreen the zones are destroyed, if its not, it is restored. For this to work there is a little change in the `setCurrentWorkspace` so that it now can (using an optional parameter) only update the layout of the monitor specified

This hereby fixes #83.