### PR TITLE
Add gnome 49 to supported shell versions

### DIFF
--- a/src/metadata.json
+++ b/src/metadata.json
@@ -3,7 +3,7 @@
   "name": "gSnap",
   "description": "Organize windows in customizable snap zones like FancyZones on Windows.",
   "version": 17,
-  "shell-version": ["45", "46", "47", "48"],
+  "shell-version": ["45", "46", "47", "48", "49"],
   "url": "https://github.com/GnomeSnapExtensions/gSnap",
   "settings-schema": "org.gnome.shell.extensions.gsnap",
   "gettext-domain": "gsnap@micahosborne"


### PR DESCRIPTION
I wrote an Issue ( #104 ) to add gnome 49 support, but after a small amount of digging it seems as easy as just increasing the supported shell versions. This is working on my local machine following the Development build/install guides.
<img width="838" height="64" alt="image" src="https://github.com/user-attachments/assets/52e9a52c-3001-4b77-b576-c8e9ebb1d5ff" />